### PR TITLE
Allow date strings for :instant to have milliseconds

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,38 +3,39 @@
   :url "https://www.github.com/zcaudate/spirit"
   :license {:name "The MIT License"
             :url "http://http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure    "1.7.0"]
-                 [im.chit/hara.common    "2.5.2"]
-                 [im.chit/hara.component "2.5.2"]
-                 [im.chit/hara.data      "2.5.2"]
-                 [im.chit/hara.event     "2.5.2"]
-                 [im.chit/hara.function  "2.5.2"]
-                 [im.chit/hara.string    "2.5.2"]
+  :dependencies [[org.clojure/clojure    "1.8.0"]
+                 [im.chit/hara.common    "2.2.17"]
+                 [im.chit/hara.component "2.2.17"]
+                 [im.chit/hara.data      "2.2.17"]
+                 [im.chit/hara.event     "2.2.17"]
+                 [im.chit/hara.function  "2.2.17"]
+                 [im.chit/hara.string    "2.2.17"]
                  [inflections "0.9.14"]]
-  
+
   :publish {:theme  "stark"
-            
+
             :template {:site   "spirit"
                        :author "Chris Zheng"
                        :email  "z@caudate.me"
                        :icon   "favicon"
                        :tracking-enabled "true"
                        :tracking "UA-31320512-2"}
-            
+
             :files {"index"
                     {:template "home.html"
                      :input "test/documentation/home_spirit.clj"
                      :title "spirit"
                      :subtitle "simplify data connectivity"}}}
-  
+
   :distribute {:jars  :dependencies
                :files [{:type :clojure
                         :levels 1
                         :path "src"}]}
-  
-  :profiles {:dev {:plugins []
+
+  :profiles {:dev {:plugins [[lein-midje "3.1.3"]]
                    :dependencies [[com.datomic/datomic-free "0.9.5561" :exclusions [joda-time]]
                                   [im.chit/hara.test  "2.5.2"]
+                                  [midje "1.8.3"]
                                   [clj-time "0.11.0"]
                                   [me.raynes/fs "1.4.6"]
                                   [cheshire "5.2.0"]]}})

--- a/test/adi/data/coerce_test.clj
+++ b/test/adi/data/coerce_test.clj
@@ -1,6 +1,7 @@
 (ns adi.data.coerce-test
   (:use midje.sweet)
-  (:require [adi.data.coerce :refer :all]))
+  (:require [adi.data.coerce :refer :all])
+  (:import (java.util Date)))
 
 ^{:refer adi.data.coerce/assoc-set :added "0.3"}
 (fact "associates a set as keys to a map"
@@ -12,6 +13,12 @@
 (fact "associates a set as keys to a map"
   (coerce 1 :string)
   => "1"
+
+  (coerce "2017-05-25T17:29:46.000Z" :instant)
+  => (Date. 117 4 25 17 29 46)
+
+  (coerce "2017-05-25T17:29:46Z" :instant)
+  => (Date. 117 4 25 17 29 46)
 
   (coerce "oeuoe" :keyword)
   => :oeuoe)


### PR DESCRIPTION
JSON dates usually are encoded like: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" not
"yyyy-MM-dd'T'HH:mm:ss'Z'". For backwards compatibility allow both.

Needed to add midje as a dependency so tests run.

Needed to update to clojure 1.8.0 for the new datomic. The error was:
java.lang.NoClassDefFoundError: clojure/lang/Tuple

Needed to revert back to version 2.2.17 of the hara libraries because of
java.lang.IllegalAccessError with version 2.5.2.